### PR TITLE
fix migrationsFolder in exampleParams.json

### DIFF
--- a/exampleParams.json
+++ b/exampleParams.json
@@ -1,5 +1,5 @@
 {
   "environmentId": "",
   "apiKey": "",
-  "migrationsPath": "./Migrations"
+  "migrationsFolder": "./Migrations"
 }


### PR DESCRIPTION
### Motivation

I had to change `migrationsPath` to `migrationsFolder` to get it to work. This took me a while to figure this out ;)
